### PR TITLE
add link to GitHub help about keeping email address private

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,4 +48,4 @@ https://api.github.com/users/your-github-username/events/public
 
 for what is being stored about yourself.
 
-If you are concerned about your email address being made public, then don't associate it with a github account.
+If you are concerned about your email address being made public, you can learn how to keep your email address private in the [GitHub documentation](https://help.github.com/articles/about-commit-email-addresses/).

--- a/README.md
+++ b/README.md
@@ -37,5 +37,4 @@ repositories. See
 
 for what is being stored about yourself.
 
-If you are concerned about your email address being made public, then
-don't associate it with a github account.
+If you are concerned about your email address being made public,  you can learn how to keep your email address private in the [GitHub documentation](https://help.github.com/articles/about-commit-email-addresses/).


### PR DESCRIPTION
in case people are concerned about having their email address listed publicly, GitHub provides a way to keep your email address private and use an alias instead. This PR adds a link to the relevant documentation.